### PR TITLE
Fix yaml.load need argument Loader raise TypeError

### DIFF
--- a/charlatan/file_format.py
+++ b/charlatan/file_format.py
@@ -124,7 +124,7 @@ def load_file(filename, use_unicode=False):
         # Load the custom YAML tags
         configure_yaml()
         configure_output(use_unicode=use_unicode)
-        content = yaml.load(content)
+        content = yaml.full_load(content)
     else:
         raise ValueError("Unsupported filetype: '%s'" % filename)
 


### PR DESCRIPTION
# Intro
After yaml upgrade to 6.x, yaml.load will raise an error like:
```
Traceback (most recent call last):
  File "<stdin>", line 3, in <module>
  File "/Users/a/repos/platform/bookings-service/.env/lib/python3.6/site-packages/charlatan/fixtures_manager.py", line 87, in load
    models_package=models_package)
  File "/Users/a/repos/platform/bookings-service/.env/lib/python3.6/site-packages/charlatan/fixtures_manager.py", line 118, in _load_fixtures
    content = load_file(globbed_filenames[0], self.use_unicode)
  File "/Users/a/repos/platform/bookings-service/.env/lib/python3.6/site-packages/charlatan/file_format.py", line 127, in load_file
    content = yaml.load(content)
TypeError: load() missing 1 required positional argument: 'Loader'
```
use pyyaml's syntactic sugar to fix the issue:
```
# old
yaml.load(steam, Loader)

# new
yaml.full_load(stream)
```

